### PR TITLE
[Changed] get endpoint to include price range

### DIFF
--- a/greenshop-api/Controllers/PlantsController.cs
+++ b/greenshop-api/Controllers/PlantsController.cs
@@ -26,6 +26,8 @@ namespace greenshop_api.Controllers
             [FromHeader(Name = "CategoryValue")] string? category = null,
             [FromHeader(Name = "SizeType")] string? size = null,
             [FromHeader(Name = "Group")] string? group = null,
+            [FromHeader(Name = "PriceMin")] double? priceMin = null,
+            [FromHeader(Name = "PriceMax")] double? priceMax = null,
             [FromHeader(Name = "Page")] int page = 1)
         {
             var plantsQuery = this.db.Plants.AsQueryable();
@@ -66,6 +68,16 @@ namespace greenshop_api.Controllers
                 {
                     plantsQuery = plantsQuery.Where(p => p.Size == SizeValue.L || p.Size == SizeValue.XL);
                 }
+            }
+
+            if(priceMin != null)
+            {
+                plantsQuery = plantsQuery.Where(p => p.Price >= priceMin);
+            }
+
+            if (priceMax != null)
+            {
+                plantsQuery = plantsQuery.Where(p => p.Price <= priceMax);
             }
 
             plantsQuery = plantsQuery.Skip((page - 1) * 9).Take(9);

--- a/greenshop-api/Filters/ActionFilters/Plant_ValidateGetHeadersAttribute.cs
+++ b/greenshop-api/Filters/ActionFilters/Plant_ValidateGetHeadersAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.EntityFrameworkCore.Storage.Json;
 
 namespace greenshop_api.Filters.ActionFilters
 {
@@ -13,7 +14,11 @@ namespace greenshop_api.Filters.ActionFilters
 
             var sizeHeaderValue = context.HttpContext.Request.Headers["SizeType"].ToString();
 
-            if(!string.IsNullOrEmpty(groupHeaderValue) && 
+            var priceMinHeaderValueString = context.HttpContext.Request.Headers["PriceMin"];
+
+            var priceMaxHeaderValueString = context.HttpContext.Request.Headers["PriceMax"];
+
+            if (!string.IsNullOrEmpty(groupHeaderValue) && 
                 !string.Equals(groupHeaderValue, "new", StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(groupHeaderValue, "sale", StringComparison.OrdinalIgnoreCase))
             {
@@ -36,6 +41,38 @@ namespace greenshop_api.Filters.ActionFilters
                     Status = StatusCodes.Status400BadRequest
                 };
                 context.Result = new BadRequestObjectResult(problemDetails);
+            }
+
+            if(!string.IsNullOrEmpty(priceMinHeaderValueString))
+            {
+                if(double.TryParse(priceMinHeaderValueString, out var priceMinHeaderValue))
+                {
+                    if (priceMinHeaderValue < 0)
+                    {
+                        context.ModelState.AddModelError("PriceMin", "Minimum Price cannot be negative.");
+                        var problemDetails = new ValidationProblemDetails(context.ModelState)
+                        {
+                            Status = StatusCodes.Status400BadRequest
+                        };
+                        context.Result = new BadRequestObjectResult(problemDetails);
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(priceMaxHeaderValueString))
+            {
+                if (double.TryParse(priceMaxHeaderValueString, out var priceMaxHeaderValue))
+                {
+                    if (priceMaxHeaderValue <= 0)
+                    {
+                        context.ModelState.AddModelError("PriceMin", "Maximum Price must be greater than 0.");
+                        var problemDetails = new ValidationProblemDetails(context.ModelState)
+                        {
+                            Status = StatusCodes.Status400BadRequest
+                        };
+                        context.Result = new BadRequestObjectResult(problemDetails);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
- Added Price Range filtering to GetPlants API Endpoint (by PriceMin and PriceMax headers)
- Included check for negative values (both PriceMin and PriceMax) and zero value (PriceMax) in GetHeaders Filter