### PR TITLE
[Fixed] Dockerfiles and MySQL Expose Port in Yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: GreenshopManagement
     ports:
-      - "3306:3306"
+      - "3307:3306"
     networks:
       - greenshop-network
 

--- a/greenshop-api/Dockerfile
+++ b/greenshop-api/Dockerfile
@@ -3,7 +3,7 @@
 #Depending on the operating system of the host machines(s) that will build or run the containers, the image specified in the FROM statement may need to be changed.
 #For more information, please see https://aka.ms/containercompat
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-1809 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081

--- a/greenshop-web/Dockerfile
+++ b/greenshop-web/Dockerfile
@@ -11,4 +11,3 @@ FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
-docker ps


### PR DESCRIPTION
- Deleted the unnecessary last line in greenshop-web Dockerfile
- Fixed Platform Configuration in greenshop-api Dockerfile
- Changed Expose Port for MySQL in YAML
