### PR TITLE
[Added] With Credentials Policy to CORS

### DIFF
--- a/greenshop-api/Controllers/AuthController.cs
+++ b/greenshop-api/Controllers/AuthController.cs
@@ -5,6 +5,7 @@ using greenshop_api.Filters.ActionFilters.Plant_ActionFilters;
 using greenshop_api.Filters.ActionFilters.UserActionFilters;
 using greenshop_api.Models;
 using greenshop_api.Services;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -72,6 +73,7 @@ namespace greenshop_api.Controllers
         }
 
         [HttpGet("user")]
+        [EnableCors("WithCredentialsPolicy")]
         public async Task<IActionResult> GetUser()
         {
             try

--- a/greenshop-api/Controllers/PlantsController.cs
+++ b/greenshop-api/Controllers/PlantsController.cs
@@ -27,6 +27,7 @@ namespace greenshop_api.Controllers
         public async Task<IActionResult> GetPlants(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 9,
+            [FromHeader(Name = "Authorized")] bool authorized = false,
             [FromHeader(Name = "SearchValue")] string? search = null,
             [FromHeader(Name = "CategoryValue")] string? category = null,
             [FromHeader(Name = "SizeType")] string? size = null,
@@ -44,7 +45,14 @@ namespace greenshop_api.Controllers
                 }
                 else if (string.Equals(group, "sale", StringComparison.OrdinalIgnoreCase))
                 {
-                    plantsQuery = plantsQuery.Where(p => p.Sale_Percent > 0);
+                    if(authorized)
+                    {
+                        plantsQuery = plantsQuery.Where(p => p.Sale_Percent_Private > 0);
+                    }
+                    else
+                    {
+                        plantsQuery = plantsQuery.Where(p => p.Sale_Percent > 0);
+                    }
                 }
             }
 

--- a/greenshop-api/Program.cs
+++ b/greenshop-api/Program.cs
@@ -19,16 +19,25 @@ builder.Services.AddCors(options =>
 {
     if (builder.Environment.IsDevelopment())
     {
-        options.AddPolicy("AllowTestingOrigins", policy =>
+        options.AddPolicy("DefaultPolicy", policy =>
             policy.WithOrigins(
                 "http://localhost:5173", 
-                "http://localhost:3000", 
-                "http://localhost:8080", 
-                "http://localhost:5050",
+                "http://localhost:3000",
                 "http://127.0.0.1:5173",
                 "http://127.0.0.1:3000")
-                  .AllowAnyMethod()
-                  .AllowAnyHeader());
+            .AllowAnyMethod()
+            .AllowAnyHeader()
+        );
+        options.AddPolicy("WithCredentialsPolicy", policy =>
+           policy.WithOrigins(
+               "http://localhost:5173",
+               "http://localhost:3000",
+               "http://127.0.0.1:5173",
+               "http://127.0.0.1:3000")
+           .AllowAnyMethod()
+           .AllowAnyHeader()
+           .AllowCredentials()
+        );
     }
 });
 
@@ -51,7 +60,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseRouting();
 
-app.UseCors("AllowTestingOrigins");
+app.UseCors("DefaultPolicy");
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
- Added new policy that allows credentials to CORS setting
- Enabled this policy for /auth/user Endpoint
- Added Authorized header to GET Plants Endpoint in order to check for private sale percentage if user is authorized